### PR TITLE
Fix include prefixes limit

### DIFF
--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -46,12 +46,12 @@ module BigShift
 
     def unload
       if run?(:unload)
-        s3_uri = "s3://#{@config[:s3_bucket_name]}/#{s3_table_prefix}/"
+        s3_uri = "s3://#{@config[:s3_bucket_name]}/#{s3_table_prefix}"
         @factory.redshift_unloader.unload_to(@config[:rs_table_name], s3_uri, allow_overwrite: false)
       else
         @logger.debug('Skipping unload')
       end
-      @unload_manifest = UnloadManifest.new(@factory.s3_resource, @config[:s3_bucket_name], "#{s3_table_prefix}/")
+      @unload_manifest = UnloadManifest.new(@factory.s3_resource, @config[:s3_bucket_name], s3_table_prefix)
     end
 
     def transfer
@@ -68,7 +68,7 @@ module BigShift
         rs_table_schema = @factory.redshift_table_schema
         bq_dataset = @factory.big_query_dataset
         bq_table = bq_dataset.table(@config[:bq_table_id]) || bq_dataset.create_table(@config[:bq_table_id])
-        gcs_uri = "gs://#{@config[:cs_bucket_name]}/#{s3_table_prefix}/*"
+        gcs_uri = "gs://#{@config[:cs_bucket_name]}/#{s3_table_prefix}*"
         options = {}
         options[:schema] = rs_table_schema.to_big_query
         options[:allow_overwrite] = true
@@ -147,12 +147,16 @@ module BigShift
     end
 
     def s3_table_prefix
-      components = @config.values_at(:rs_database_name, :rs_table_name)
-      if (prefix = @config[:s3_prefix])
-        prefix = prefix.gsub(%r{\A/|/\Z}, '')
-        components.unshift(prefix)
+      @s3_table_prefix ||= begin
+        db_name = @config[:rs_database_name]
+        table_name = @config[:rs_table_name]
+        prefix = "#{db_name}/#{table_name}/#{db_name}-#{table_name}-"
+        if (s3_prefix = @config[:s3_prefix])
+          s3_prefix = s3_prefix.gsub(%r{\A/|/\Z}, '')
+          prefix = "#{s3_prefix}/#{prefix}"
+        end
+        prefix
       end
-      File.join(*components)
     end
   end
 

--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -51,7 +51,7 @@ module BigShift
       else
         @logger.debug('Skipping unload')
       end
-      @unload_manifest = UnloadManifest.new(@factory.s3_resource, @config[:s3_bucket_name], s3_table_prefix)
+      @unload_manifest = @factory.create_unload_manifest(@config[:s3_bucket_name], s3_table_prefix)
     end
 
     def transfer
@@ -194,6 +194,10 @@ module BigShift
 
     def logger
       @logger ||= Logger.new($stderr)
+    end
+
+    def create_unload_manifest(s3_bucket_name, s3_table_prefix)
+      UnloadManifest.new(s3_resource, cs_service, @config[:s3_bucket_name], s3_table_prefix)
     end
 
     private

--- a/lib/bigshift/cloud_storage_transfer.rb
+++ b/lib/bigshift/cloud_storage_transfer.rb
@@ -45,7 +45,8 @@ module BigShift
             bucket_name: cloud_storage_bucket
           ),
           object_conditions: Google::Apis::StoragetransferV1::ObjectConditions.new(
-            include_prefixes: unload_manifest.keys,
+            include_prefixes: [unload_manifest.prefix],
+            exclude_prefixes: [unload_manifest.manifest_key]
           ),
           transfer_options: Google::Apis::StoragetransferV1::TransferOptions.new(
             overwrite_objects_already_existing_in_sink: !!allow_overwrite

--- a/lib/bigshift/cloud_storage_transfer.rb
+++ b/lib/bigshift/cloud_storage_transfer.rb
@@ -15,6 +15,7 @@ module BigShift
       transfer_job = @storage_transfer_service.create_transfer_job(transfer_job)
       @logger.info(sprintf('Transferring %d objects (%.2f GiB) from s3://%s/%s to gs://%s/%s', unload_manifest.count, unload_manifest.total_file_size.to_f/2**30, unload_manifest.bucket_name, unload_manifest.prefix, cloud_storage_bucket, unload_manifest.prefix))
       await_completion(transfer_job, poll_interval)
+      validate_transfer(unload_manifest, cloud_storage_bucket)
       nil
     end
 
@@ -100,6 +101,11 @@ module BigShift
         end
         @logger.info(message)
       end
+    end
+
+    def validate_transfer(unload_manifest, cloud_storage_bucket)
+      unload_manifest.validate_transfer(cloud_storage_bucket)
+      @logger.info('Transfer validated, all file sizes match')
     end
   end
 end

--- a/lib/bigshift/unload_manifest.rb
+++ b/lib/bigshift/unload_manifest.rb
@@ -1,9 +1,12 @@
 module BigShift
+  TransferValidationError = Class.new(BigShiftError)
+
   class UnloadManifest
     attr_reader :bucket_name, :prefix, :manifest_key
 
-    def initialize(s3_resource, bucket_name, prefix)
+    def initialize(s3_resource, cs_service, bucket_name, prefix)
       @s3_resource = s3_resource
+      @cs_service = cs_service
       @bucket_name = bucket_name
       @prefix = prefix
       @manifest_key = "#{@prefix}manifest"
@@ -23,14 +26,43 @@ module BigShift
     end
 
     def total_file_size
-      @total_file_size ||= begin
+      @total_file_size ||= file_sizes.values.reduce(:+)
+    end
+
+    def validate_transfer(cs_bucket_name)
+      objects = @cs_service.list_objects(cs_bucket_name, prefix: @prefix)
+      cs_file_sizes = objects.items.each_with_object({}) do |item, acc|
+        acc[item.name] = item.size.to_i
+      end
+      missing_files = (file_sizes.keys - cs_file_sizes.keys)
+      extra_files = cs_file_sizes.keys - file_sizes.keys
+      common_files = (cs_file_sizes.keys & file_sizes.keys)
+      size_mismatches = common_files.select { |name| file_sizes[name] != cs_file_sizes[name] }
+      errors = []
+      unless missing_files.empty?
+        errors << "missing files: #{missing_files.join(', ')}"
+      end
+      unless extra_files.empty?
+        errors << "extra files: #{extra_files.join(', ')}"
+      end
+      unless size_mismatches.empty?
+        messages = size_mismatches.map { |name| sprintf('%s (%d != %d)', name, cs_file_sizes[name], file_sizes[name]) }
+        errors << "size mismatches: #{messages.join(', ')}"
+      end
+      unless errors.empty?
+        raise TransferValidationError, "Transferred files don't match unload manifest: #{errors.join('; ')}"
+      end
+    end
+
+    private
+
+    def file_sizes
+      @file_sizes ||= begin
         bucket = @s3_resource.bucket(@bucket_name)
         objects = bucket.objects(prefix: @prefix)
-        objects.reduce(0) do |sum, object|
+        objects.each_with_object({}) do |object, acc|
           if keys.include?(object.key)
-            sum + object.size
-          else
-            sum
+            acc[object.key] = object.size
           end
         end
       end

--- a/spec/bigshift/cli_spec.rb
+++ b/spec/bigshift/cli_spec.rb
@@ -118,7 +118,7 @@ module BigShift
     describe '#run' do
       it 'unloads the Redshift table to S3' do
         cli.run
-        expect(redshift_unloader).to have_received(:unload_to).with('the_rs_table', 's3://the-s3-staging-bucket/the_rs_database/the_rs_table/', anything)
+        expect(redshift_unloader).to have_received(:unload_to).with('the_rs_table', 's3://the-s3-staging-bucket/the_rs_database/the_rs_table/the_rs_database-the_rs_table-', anything)
       end
 
       it 'does not allow the S3 location to be overwritten' do
@@ -135,7 +135,7 @@ module BigShift
         aggregate_failures do
           expect(cloud_storage_transfer).to have_received(:copy_to_cloud_storage).with(anything, 'the-cs-bucket', anything)
           expect(unload_manifest.bucket_name).to eq('the-s3-staging-bucket')
-          expect(unload_manifest.prefix).to eq('the_rs_database/the_rs_table/')
+          expect(unload_manifest.prefix).to eq('the_rs_database/the_rs_table/the_rs_database-the_rs_table-')
         end
       end
 
@@ -155,7 +155,7 @@ module BigShift
 
       it 'loads the transferred data' do
         cli.run
-        expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/the_rs_database/the_rs_table/*', anything)
+        expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/the_rs_database/the_rs_table/the_rs_database-the_rs_table-*', anything)
       end
 
       it 'loads the transferred data into a table with the same name as the Redshift table' do
@@ -215,7 +215,7 @@ module BigShift
 
         it 'unloads to a location on S3 under the specified prefix' do
           cli.run
-          expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/', anything)
+          expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-', anything)
         end
 
         it 'transfers that S3 location' do
@@ -224,12 +224,12 @@ module BigShift
             unload_manifest = um
           end
           cli.run
-          expect(unload_manifest.prefix).to eq('and/the/prefix/the_rs_database/the_rs_table/')
+          expect(unload_manifest.prefix).to eq('and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-')
         end
 
         it 'loads from that location' do
           cli.run
-          expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/*', anything)
+          expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-*', anything)
         end
 
         context 'and it has a slash prefix or suffix' do
@@ -237,8 +237,8 @@ module BigShift
             argv[-1] = '/and/the/prefix'
             cli.run
             aggregate_failures do
-              expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/', anything)
-              expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/*', anything)
+              expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-', anything)
+              expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-*', anything)
             end
           end
 
@@ -246,8 +246,8 @@ module BigShift
             argv[-1] = 'and/the/prefix/'
             cli.run
             aggregate_failures do
-              expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/', anything)
-              expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/*', anything)
+              expect(redshift_unloader).to have_received(:unload_to).with(anything, 's3://the-s3-staging-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-', anything)
+              expect(big_query_table).to have_received(:load).with('gs://the-cs-bucket/and/the/prefix/the_rs_database/the_rs_table/the_rs_database-the_rs_table-*', anything)
             end
           end
         end

--- a/spec/bigshift/cli_spec.rb
+++ b/spec/bigshift/cli_spec.rb
@@ -107,6 +107,7 @@ module BigShift
       allow(factory).to receive(:cleaner).and_return(cleaner)
       allow(factory).to receive(:s3_resource).and_return(nil)
       allow(factory).to receive(:logger).and_return(logger)
+      allow(factory).to receive(:create_unload_manifest) { |s3_bucket_name, s3_table_prefix| UnloadManifest.new(nil, nil, s3_bucket_name, s3_table_prefix) }
       allow(redshift_unloader).to receive(:unload_to)
       allow(cloud_storage_transfer).to receive(:copy_to_cloud_storage)
       allow(big_query_dataset).to receive(:table).with('the_rs_table').and_return(big_query_table)

--- a/spec/bigshift/unload_manifest_spec.rb
+++ b/spec/bigshift/unload_manifest_spec.rb
@@ -1,11 +1,15 @@
 module BigShift
   describe UnloadManifest do
     let :manifest do
-      described_class.new(s3_resource, 'my-bucket', 'some/prefix/')
+      described_class.new(s3_resource, cs_service, 'my-bucket', 'some/prefix/')
     end
 
     let :s3_resource do
       double(:s3_resource)
+    end
+
+    let :cs_service do
+      double(:cs_service)
     end
 
     let :s3_bucket do
@@ -26,12 +30,22 @@ module BigShift
       }
     end
 
+    let :cs_items do
+      []
+    end
+
+    let :s3_objects do
+      []
+    end
+
     before do
       manifest_result = double(:manifest_result)
       allow(s3_resource).to receive(:bucket).with('my-bucket').and_return(s3_bucket)
       allow(s3_bucket).to receive(:object).with('some/prefix/manifest').and_return(manifest_object)
+      allow(s3_bucket).to receive(:objects).with(prefix: 'some/prefix/').and_return(s3_objects)
       allow(manifest_object).to receive(:get).and_return(manifest_result)
       allow(manifest_result).to receive(:body).and_return(JSON.dump(raw_manifest))
+      allow(cs_service).to receive(:list_objects).with('cs-bucket', prefix: 'some/prefix/').and_return(double(:cs_listing, items: cs_items))
     end
 
     describe '#bucket_name' do
@@ -75,16 +89,12 @@ module BigShift
     end
 
     describe '#total_file_size' do
-      let :objects do
+      let :s3_objects do
         [
           double(:object1, key: 'some/prefix/0000_part_00', size: 3),
           double(:object2, key: 'some/prefix/0001_part_00', size: 5),
           double(:object3, key: 'some/prefix/0002_part_00', size: 7),
         ]
-      end
-
-      before do
-        allow(s3_bucket).to receive(:objects).with(prefix: 'some/prefix/').and_return(objects)
       end
 
       it 'lists the files and sums up their total size, in bytes' do
@@ -98,7 +108,7 @@ module BigShift
       end
 
       context 'when the listing contains files not in the manifest' do
-        let :objects do
+        let :s3_objects do
           [
             double(:object1, key: 'some/prefix/0000_part_00', size: 3),
             double(:object2, key: 'some/prefix/0001_part_00', size: 5),
@@ -110,6 +120,62 @@ module BigShift
 
         it 'lists the files and sums up their total size, in bytes' do
           expect(manifest.total_file_size).to eq(3 + 5 + 7)
+        end
+      end
+    end
+
+    describe '#validate_transfer' do
+      let :cs_items do
+        [
+          double(:cs_item, name: 'some/prefix/0000_part_00', size: '3'),
+          double(:cs_item, name: 'some/prefix/0001_part_00', size: '5'),
+          double(:cs_item, name: 'some/prefix/0002_part_00', size: '7'),
+
+        ]
+      end
+
+      let :s3_objects do
+        [
+          double(:object1, key: 'some/prefix/0000_part_00', size: 3),
+          double(:object2, key: 'some/prefix/0001_part_00', size: 5),
+          double(:object3, key: 'some/prefix/0002_part_00', size: 7),
+        ]
+      end
+
+      it 'checks that the files in the specified CS bucket match the files in the manifest' do
+        expect { manifest.validate_transfer('cs-bucket') }.to_not raise_error
+      end
+
+      context 'when files are missing' do
+        before do
+          cs_items.shift
+          cs_items.pop
+        end
+
+        it 'raises an error' do
+          expect { manifest.validate_transfer('cs-bucket') }.to raise_error(TransferValidationError, %r{missing files: some/prefix/0000_part_00, some/prefix/0002_part_00})
+        end
+      end
+
+      context 'when there are more files' do
+        before do
+          cs_items.unshift(double(:cs_item, name: 'some/prefix/0003_part_00', size: '9'))
+          cs_items.push(double(:cs_item, name: 'some/prefix/0004_part_00', size: '11'))
+        end
+
+        it 'raises an error' do
+          expect { manifest.validate_transfer('cs-bucket') }.to raise_error(TransferValidationError, %r{extra files: some/prefix/0003_part_00, some/prefix/0004_part_00})
+        end
+      end
+
+      context 'when a file has the wrong size' do
+        before do
+          allow(cs_items[0]).to receive(:size).and_return('4')
+          allow(cs_items[2]).to receive(:size).and_return('4')
+        end
+
+        it 'raises an error' do
+          expect { manifest.validate_transfer('cs-bucket') }.to raise_error(TransferValidationError, %r{size mismatches: some/prefix/0000_part_00 \(4 != 3\), some/prefix/0002_part_00 \(4 != 7\)})
         end
       end
     end


### PR DESCRIPTION
This addresses #1 by reversing the old strategy of specifying exactly the files in the unload manifest and instead going back to transferring everything in the prefix, but excluding the manifest.

To make it less likely that the prefix contains other files it is no longer just a directory, The transfer is also validated after the transfer completes. If any files are missing, if there are too many files, or if any files have a different size than the ones in the manifest the transfer fails with an error that explains exactly what the problem is.