### PR TITLE
Make it possible to disable compression

### DIFF
--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -47,7 +47,7 @@ module BigShift
     def unload
       if run?(:unload)
         s3_uri = "s3://#{@config[:s3_bucket_name]}/#{s3_table_prefix}"
-        @factory.redshift_unloader.unload_to(@config[:rs_table_name], s3_uri, allow_overwrite: false)
+        @factory.redshift_unloader.unload_to(@config[:rs_table_name], s3_uri, allow_overwrite: false, compression: @config[:compression])
       else
         @logger.debug('Skipping unload')
       end
@@ -107,6 +107,7 @@ module BigShift
       ['--cs-bucket', 'BUCKET_NAME', String, :cs_bucket_name, :required],
       ['--max-bad-records', 'N', Integer, :max_bad_records, nil],
       ['--steps', 'STEPS', Array, :steps, nil],
+      ['--[no-]compression', nil, nil, :compression, nil],
     ]
 
     def parse_args(argv)

--- a/lib/bigshift/redshift_unloader.rb
+++ b/lib/bigshift/redshift_unloader.rb
@@ -17,8 +17,8 @@ module BigShift
       unload_sql << %Q< TO '#{s3_uri}'>
       unload_sql << %Q< CREDENTIALS '#{credentials_string}'>
       unload_sql << %q< MANIFEST>
-      unload_sql << %q< GZIP>
       unload_sql << %q< DELIMITER '\t'>
+      unload_sql << %q< GZIP> if options.fetch(:compression, true)
       unload_sql << %q< ALLOWOVERWRITE> if options[:allow_overwrite]
       @logger.info(sprintf('Unloading Redshift table %s to %s', table_name, s3_uri))
       @redshift_connection.exec(unload_sql)

--- a/spec/bigshift/cli_spec.rb
+++ b/spec/bigshift/cli_spec.rb
@@ -416,6 +416,17 @@ module BigShift
         end
       end
 
+      context 'when --no-compression is specified' do
+        let :argv do
+          super() + ['--no-compression']
+        end
+
+        it 'tells the unloader not to compress the unloaded data' do
+          cli.run
+          expect(redshift_unloader).to have_received(:unload_to).with(anything, anything, hash_including(compression: false))
+        end
+      end
+
       %w[
         --rs-database
         --rs-table

--- a/spec/bigshift/redshift_unloader_spec.rb
+++ b/spec/bigshift/redshift_unloader_spec.rb
@@ -108,6 +108,16 @@ module BigShift
         end
       end
 
+      context 'when the :compression option is false' do
+        let :unload_options do
+          super().merge(compression: false)
+        end
+
+        it 'does not include GZIP in the unload command' do
+          expect(unload_command).to_not include(%q<GZIP>)
+        end
+      end
+
       context 'when Redshift datatypes need to be converted' do
         let :column_rows do
           super() << {'column' => 'alive', 'type' => 'boolean', 'notnull' => 't'}


### PR DESCRIPTION
This adds a workaround for #2: run BigShift with `--no-compression` to avoid running into the 4 GiB compressed files limit in BigQuery.