### PR TITLE
Collected fixes for open issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,6 @@ The certificates used by the Google APIs might not be installed on your system, 
 export SSL_CERT_FILE="$(find $GEM_HOME/gems -name 'google-api-client-*' | tail -n 1)/lib/cacerts.pem"
 ```
 
-### BigQuery says my files are not splittable and too large
-
-For example:
-
-> Input CSV files are not splittable and at least one of the files is larger than the maximum allowed size. Size is: 5838980665. Max allowed size is: 4294967296. Filename: gs://bigshift/foo/bar/foo-bar-0039_part_00.gz
-
-This happens when the (compressed) files exceed 4 GiB in size. Unfortunately it is not possible to control the size of the files produced by Redshift's `UNLOAD` command, and the size of the files will depend on the number of nodes in your cluster and the amount of data you're dumping.
-
-There are two options: either you use BigShift to get the dumps to GCS and then manually uncompress and load them (use `--steps unload,transfer`) or you dump without compression (use `--no-compression`). Keep in mind that without compression the bandwidth costs will be significanly higher.
-
 ### I get errors when the data is loaded into BigQuery
 
 This could be anything, but it could be things that aren't escaped properly when the data is dumped from Redshift. Try figuring out from the errors where the problem is and what the data looks like and open an issue. The more you can figure out yourself the more likely it is that you will get help. No one wants to trawl through your data, make an effort.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Running `bigshift` without any arguments, or with `--help` will show the options
 
 You can provide GCP credentials either with the environment variable `GOOGLE_APPLICATION_CREDENTIALS` or with the `--gcp-credentials` argument. These must be a path to a JSON file that contains a public/private key pair for a GCP user. The best way to obtain this is to create a new service account and choose JSON as the key type when prompted. See the [GCP documentation](https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually) for more information.
 
+If Bigshift is run directly on Compute Engine, Kubernetes Engine or App Engine flexible environment, the embedded service account will be used instead. Please note the service account will need to have the `cloud-platform` authorization scope as detailed in the [Storage Transfer Service documentation](https://cloud.google.com/storage-transfer/docs/create-client#scope).
+
 If you haven't used Storage Transfer Service with your destination bucket before it might not have the right permissions setup, see below under [Troubleshooting](#insufficientpermissionswhentransferringtogcs) for more information.
 
 ### AWS credentials

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ You can verify that this has been set up by inspecting the permissions for your 
 
 If the permission on the bucket isn't there, the Storage Transfer service won't be able to find the bucket and will fail. You might see an error like "Failed to obtain the location of the destination Google Cloud Storage (GCS) bucket due to insufficient permissions".
 
+### I get a NoMethodError: undefined method 'match' for nil:NilClass
+
+This appears to be a bug in the AWS SDK that manifests when your [AWS credentials](#aws-credentials) have not been properly specified.
+
 # Copyright
 
 © 2016 Theo Hultberg and contributors, see LICENSE.txt (BSD 3-Clause).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Running `bigshift` without any arguments, or with `--help` will show the options
 
 ### GCP credentials
 
-The `--gcp-credentials` argument must be a path to a JSON file that contains a public/private key pair for a GCP user. The best way to obtain this is to create a new service account and chose JSON as the key type when prompted.
+You can provide GCP credentials either with the environment variable `GOOGLE_APPLICATION_CREDENTIALS` or with the `--gcp-credentials` argument. These must be a path to a JSON file that contains a public/private key pair for a GCP user. The best way to obtain this is to create a new service account and choose JSON as the key type when prompted. See the [GCP documentation](https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually) for more information.
 
 If you haven't used Storage Transfer Service with your destination bucket before it might not have the right permissions setup, see below under [Troubleshooting](#insufficientpermissionswhentransferringtogcs) for more information.
 

--- a/bigshift.gemspec
+++ b/bigshift.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'pg'
   s.add_runtime_dependency 'google-api-client', '~> 0.9'
   s.add_runtime_dependency 'googleauth'
+  s.add_runtime_dependency 'google-cloud-env'
   s.add_runtime_dependency 'aws-sdk'
 end

--- a/lib/bigshift.rb
+++ b/lib/bigshift.rb
@@ -1,6 +1,7 @@
 require 'google/apis/bigquery_v2'
 require 'google/apis/storagetransfer_v1'
 require 'google/apis/storage_v1'
+require "google/cloud/env"
 require 'aws-sdk'
 
 module BigShift

--- a/lib/bigshift.rb
+++ b/lib/bigshift.rb
@@ -1,7 +1,7 @@
 require 'google/apis/bigquery_v2'
 require 'google/apis/storagetransfer_v1'
 require 'google/apis/storage_v1'
-require "google/cloud/env"
+require 'google/cloud/env'
 require 'aws-sdk'
 
 module BigShift

--- a/lib/bigshift/big_query/table.rb
+++ b/lib/bigshift/big_query/table.rb
@@ -36,11 +36,7 @@ module BigShift
             else
               job.status.errors.each do |error|
                 message = %<Load error: "#{error.message}">
-                if error.location
-                  file, line, field = error.location.split('/').map { |s| s.split(':').last.strip }
-                  message << " at file #{file}, line #{line}"
-                  message << ", field #{field}" if field
-                end
+                message << " in #{error.location}" if error.location
                 @logger.debug(message)
               end
               raise job.status.error_result.message

--- a/lib/bigshift/big_query/table.rb
+++ b/lib/bigshift/big_query/table.rb
@@ -18,6 +18,7 @@ module BigShift
         load_configuration[:source_format] = 'CSV'
         load_configuration[:field_delimiter] = '\t'
         load_configuration[:quote] = '"'
+        load_configuration[:allow_quoted_newlines] = true
         load_configuration[:destination_table] = @table_data.table_reference
         load_configuration[:max_bad_records] = options[:max_bad_records] if options[:max_bad_records]
         job = Google::Apis::BigqueryV2::Job.new(

--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -36,7 +36,7 @@ module BigShift
         if ['access_key_id', 'match'].any? { |key| e.message.include? key }
           raise CliError.new('AWS configuration missing or malformed: ' + e.message, e.backtrace, @usage)
         else
-          raise CliError.new(e.message, e.backtrace, @usage)
+          raise e
         end
       rescue Signet::AuthorizationError => e
         raise CliError.new('GCP configuration missing or malformed: ' + e.message, e.backtrace, @usage)

--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -266,10 +266,7 @@ module BigShift
       @aws_credentials ||= begin
         if @config[:aws_credentials]
           credentials = Aws::Credentials.new(*@config[:aws_credentials].values_at('access_key_id', 'secret_access_key'))
-        else
-          credentials = nil
-        end
-        if (credentials = Aws::CredentialProviderChain.new(credentials).resolve)
+        elsif (credentials = Aws::CredentialProviderChain.new().resolve)
           credentials
         else
           raise 'No AWS credentials found'

--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -221,7 +221,7 @@ module BigShift
     private
 
     def rs_connection
-      @rs_connection ||= PG.connect(
+      @rs_connection = PG.connect(
         host: @config[:rs_credentials]['host'],
         port: @config[:rs_credentials]['port'],
         dbname: @config[:rs_database_name],

--- a/lib/bigshift/cli.rb
+++ b/lib/bigshift/cli.rb
@@ -106,7 +106,7 @@ module BigShift
     ].freeze
 
     ARGUMENTS = [
-      ['--gcp-credentials', 'PATH', String, :gcp_credentials_path, :required],
+      ['--gcp-credentials', 'PATH', String, :gcp_credentials_path, nil],
       ['--aws-credentials', 'PATH', String, :aws_credentials_path, nil],
       ['--rs-credentials', 'PATH', String, :rs_credentials_path, :required],
       ['--rs-database', 'DB_NAME', String, :rs_database_name, :required],
@@ -134,6 +134,9 @@ module BigShift
         parser.parse!(argv)
       rescue OptionParser::InvalidOption => e
         config_errors << e.message
+      end
+      if !config[:gcp_credentials_path] && ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        config[:gcp_credentials_path] = ENV['GOOGLE_APPLICATION_CREDENTIALS']
       end
       %w[gcp aws rs].each do |prefix|
         if (path = config["#{prefix}_credentials_path".to_sym]) && File.exist?(path)

--- a/lib/bigshift/cloud_storage_transfer.rb
+++ b/lib/bigshift/cloud_storage_transfer.rb
@@ -24,15 +24,15 @@ module BigShift
     DEFAULT_POLL_INTERVAL = 30
 
     def create_transfer_job(unload_manifest, cloud_storage_bucket, description, allow_overwrite)
-      now = @clock.now.utc + 60
+      soon = @clock.now.utc + 60
       Google::Apis::StoragetransferV1::TransferJob.new(
         description: description,
         project_id: @project_id,
         status: 'ENABLED',
         schedule: Google::Apis::StoragetransferV1::Schedule.new(
-          schedule_start_date: Google::Apis::StoragetransferV1::Date.new(year: now.year, month: now.month, day: now.day),
-          schedule_end_date: Google::Apis::StoragetransferV1::Date.new(year: now.year, month: now.month, day: now.day),
-          start_time_of_day: Google::Apis::StoragetransferV1::TimeOfDay.new(hours: now.hour, minutes: now.min)
+          schedule_start_date: Google::Apis::StoragetransferV1::Date.new(year: soon.year, month: soon.month, day: soon.day),
+          schedule_end_date: Google::Apis::StoragetransferV1::Date.new(year: soon.year, month: soon.month, day: soon.day),
+          start_time_of_day: Google::Apis::StoragetransferV1::TimeOfDay.new(hours: soon.hour, minutes: soon.min)
         ),
         transfer_spec: Google::Apis::StoragetransferV1::TransferSpec.new(
           aws_s3_data_source: Google::Apis::StoragetransferV1::AwsS3Data.new(

--- a/lib/bigshift/cloud_storage_transfer.rb
+++ b/lib/bigshift/cloud_storage_transfer.rb
@@ -24,7 +24,7 @@ module BigShift
     DEFAULT_POLL_INTERVAL = 30
 
     def create_transfer_job(unload_manifest, cloud_storage_bucket, description, allow_overwrite)
-      now = @clock.now.utc
+      now = @clock.now.utc + 60
       Google::Apis::StoragetransferV1::TransferJob.new(
         description: description,
         project_id: @project_id,
@@ -32,7 +32,7 @@ module BigShift
         schedule: Google::Apis::StoragetransferV1::Schedule.new(
           schedule_start_date: Google::Apis::StoragetransferV1::Date.new(year: now.year, month: now.month, day: now.day),
           schedule_end_date: Google::Apis::StoragetransferV1::Date.new(year: now.year, month: now.month, day: now.day),
-          start_time_of_day: Google::Apis::StoragetransferV1::TimeOfDay.new(hours: now.hour, minutes: now.min + 1)
+          start_time_of_day: Google::Apis::StoragetransferV1::TimeOfDay.new(hours: now.hour, minutes: now.min)
         ),
         transfer_spec: Google::Apis::StoragetransferV1::TransferSpec.new(
           aws_s3_data_source: Google::Apis::StoragetransferV1::AwsS3Data.new(

--- a/lib/bigshift/redshift_table_schema.rb
+++ b/lib/bigshift/redshift_table_schema.rb
@@ -60,12 +60,10 @@ module BigShift
 
       def to_sql
         case @type
-        when /^numeric/, /int/, /^double/, 'real'
+        when /^numeric/, /int/, /^double/, 'real', /^timestamp/
           sprintf('"%s"', @name)
         when /^character/
           sprintf(%q<('"' || REPLACE(REPLACE(REPLACE("%s", '"', '""'), '\\n', '\\\\n'), '\\r', '\\\\r') || '"')>, @name)
-        when /^timestamp/
-          sprintf('(EXTRACT(epoch FROM "%s") + EXTRACT(milliseconds FROM "%s")/1000.0)', @name, @name)
         when 'date'
           sprintf(%q<(TO_CHAR("%s", 'YYYY-MM-DD'))>, @name)
         when 'boolean'

--- a/lib/bigshift/redshift_table_schema.rb
+++ b/lib/bigshift/redshift_table_schema.rb
@@ -8,16 +8,16 @@ module BigShift
 
     def columns
       @columns ||= begin
-        query = p %{
+        query = %{
           SELECT "column", "type", "notnull"
-          FROM "pg_table_def" ptd, information_schema.columns isc
+          FROM pg_table_def ptd, information_schema.columns isc
           WHERE ptd.schemaname = isc.table_schema
           AND ptd.tablename = isc.table_name
           AND ptd.column = isc.column_name
-          AND "schemaname" = $1
-          AND "tablename" = $2
+          AND schemaname = $1
+          AND tablename = $2
           ORDER BY ordinal_position
-        }.gsub(/\s+/, " ").strip
+        }.gsub(/\s+/, ' ').strip
         rows = @redshift_connection.exec_params(query, [@schema_name, @table_name])
         if rows.count == 0
           raise sprintf('Table %s for schema %s not found', @table_name.inspect, @schema_name.inspect)

--- a/lib/bigshift/redshift_unloader.rb
+++ b/lib/bigshift/redshift_unloader.rb
@@ -20,6 +20,7 @@ module BigShift
       unload_sql << %q< DELIMITER '\t'>
       unload_sql << %q< GZIP> if options[:compression] || options[:compression].nil?
       unload_sql << %q< ALLOWOVERWRITE> if options[:allow_overwrite]
+      unload_sql << %q< MAXFILESIZE 3.9 GB>
       @logger.info(sprintf('Unloading Redshift table %s to %s', table_name, s3_uri))
       @redshift_connection.exec(unload_sql)
       @logger.info(sprintf('Unload of %s complete', table_name))

--- a/spec/bigshift/big_query/table_spec.rb
+++ b/spec/bigshift/big_query/table_spec.rb
@@ -212,9 +212,9 @@ module BigShift
             it 'logs the errors' do
               table.load('my_uri') rescue nil
               aggregate_failures do
-                expect(logger).to have_received(:debug).with('Load error: "Bad thing" at file 0, line 5, field 18')
-                expect(logger).to have_received(:debug).with('Load error: "Not correct" at file 1, line 6')
-                expect(logger).to have_received(:debug).with('Load error: "Do better" at file 2, line 7, field 20')
+                expect(logger).to have_received(:debug).with('Load error: "Bad thing" in File: 0 / Line:5 / Field:18')
+                expect(logger).to have_received(:debug).with('Load error: "Not correct" in File: 1 / Line:6')
+                expect(logger).to have_received(:debug).with('Load error: "Do better" in File: 2 / Line:7 / Field:20')
               end
             end
 

--- a/spec/bigshift/cli_spec.rb
+++ b/spec/bigshift/cli_spec.rb
@@ -298,7 +298,7 @@ module BigShift
         end
       end
 
-      %w[gcp rs].each do |prefix|
+      %w[rs].each do |prefix|
         context "when --#{prefix}-credentials is not specified" do
           let :argv do
             a = super()

--- a/spec/bigshift/cli_spec.rb
+++ b/spec/bigshift/cli_spec.rb
@@ -298,41 +298,40 @@ module BigShift
         end
       end
 
-      %w[rs].each do |prefix|
-        context "when --#{prefix}-credentials is not specified" do
-          let :argv do
-            a = super()
-            i = a.index("--#{prefix}-credentials")
-            a.delete_at(i)
-            a.delete_at(i)
-            a
-          end
 
-          it 'raises an error' do
-            error = nil
-            begin
-              cli.run
-            rescue => e
-              error = e
-            end
-            expect(error.details).to include("--#{prefix}-credentials is required")
-          end
+      context "when --rs-credentials is not specified" do
+        let :argv do
+          a = super()
+          i = a.index("--rs-credentials")
+          a.delete_at(i)
+          a.delete_at(i)
+          a
         end
 
-        context "when the path given to --#{prefix}-credentials does not exist" do
-          before do
-            FileUtils.rm_f("#{prefix}-credentials.yml")
+        it 'raises an error' do
+          error = nil
+          begin
+            cli.run
+          rescue => e
+            error = e
           end
+          expect(error.details).to include("--rs-credentials is required")
+        end
+      end
 
-          it 'raises an error' do
-            error = nil
-            begin
-              cli.run
-            rescue => e
-              error = e
-            end
-            expect(error.details).to include(%<"#{prefix}-credentials.yml" does not exist>)
+      context "when the path given to --rs-credentials does not exist" do
+        before do
+          FileUtils.rm_f("rs-credentials.yml")
+        end
+
+        it 'raises an error' do
+          error = nil
+          begin
+            cli.run
+          rescue => e
+            error = e
           end
+          expect(error.details).to include(%<"rs-credentials.yml" does not exist>)
         end
       end
 

--- a/spec/bigshift/redshift_table_schema_spec.rb
+++ b/spec/bigshift/redshift_table_schema_spec.rb
@@ -24,14 +24,15 @@ module BigShift
     describe '#columns' do
       it 'queries the pg_table_def table filtering by the specified table' do
         table_schema.columns
-        expect(redshift_connection).to have_received(:exec_params).with(
-          include(%q<FROM pg_table_def ptd, information_schema.columns isc>).
-          and(include(%q<WHERE ptd.schemaname = isc.table_schema AND ptd.tablename = isc.table_name AND ptd.column = isc.column_name>)).
-          and(include(%q<ORDER BY ordinal_position>)), anything
-        )
+        expect(redshift_connection).to have_received(:exec_params).with(anything, ['some_schema', 'some_table'])
       end
 
       it 'loads the column names, types and nullity' do
+        table_schema.columns
+        expect(redshift_connection).to have_received(:exec_params).with(/SELECT "column", "type", "notnull"/, anything)
+      end
+
+      it 'identifies and preserves the columnn ordering' do
         table_schema.columns
         expect(redshift_connection).to have_received(:exec_params).with(
           include(%q<FROM pg_table_def ptd, information_schema.columns isc>).

--- a/spec/bigshift/redshift_table_schema_spec.rb
+++ b/spec/bigshift/redshift_table_schema_spec.rb
@@ -18,7 +18,7 @@ module BigShift
     end
 
     before do
-      allow(redshift_connection).to receive(:exec_params).with(/SELECT .+ FROM "pg_table_def" WHERE "schemaname" = \$1 AND "tablename" = \$2/, anything).and_return(column_rows)
+      allow(redshift_connection).to receive(:exec_params).with(/SELECT .+ FROM "pg_table_def" ptd, information_schema.columns isc WHERE ptd.schemaname = isc.table_schema AND ptd.tablename = isc.table_name AND ptd.column = isc.column_name AND "schemaname" = \$1 AND "tablename" = \$2 ORDER BY ordinal_position/, anything).and_return(column_rows)
     end
 
     describe '#columns' do
@@ -29,7 +29,7 @@ module BigShift
 
       it 'loads the column names, types and nullity' do
         table_schema.columns
-        expect(redshift_connection).to have_received(:exec_params).with(/SELECT "column", "type", "notnull"/, anything)
+        expect(redshift_connection).to have_received(:exec_params).with(/SELECT "column", "type", "notnull" FROM "pg_table_def" ptd, information_schema.columns isc WHERE ptd.schemaname = isc.table_schema AND ptd.tablename = isc.table_name AND ptd.column = isc.column_name AND "schemaname" = \$1 AND "tablename" = \$2 ORDER BY ordinal_position/, anything)
       end
 
       it 'returns all columns as Column objects' do
@@ -46,9 +46,9 @@ module BigShift
         end
       end
 
-      it 'returns the columns in alphabetical order' do
+      it 'returns the columns in original order' do
         columns = table_schema.columns
-        expect(columns.map(&:name)).to eq(%w[fax_number id name year_of_birth])
+        expect(columns.map(&:name)).to eq(%w[id name fax_number year_of_birth])
       end
     end
 
@@ -70,8 +70,8 @@ module BigShift
           end
         end
 
-        it 'contains all Redshift columns as fields, in alphabetical order' do
-          expect(big_query_table_schema.fields.map(&:name)).to eq(%w[fax_number id name year_of_birth])
+        it 'contains all Redshift columns as fields, in original order' do
+          expect(big_query_table_schema.fields.map(&:name)).to eq(%w[id name fax_number year_of_birth])
         end
 
         it 'sets the mode to REQUIRED where NOT NULL and NULLABLE where NULL in Redshift' do
@@ -231,16 +231,6 @@ module BigShift
           it 'returns SQL that converts the value to 1, 0 or NULL' do
             expect(column.to_sql).to eq('(CASE WHEN "the_column" IS NULL THEN NULL WHEN "the_column" THEN 1 ELSE 0 END)')
           end
-        end
-      end
-
-      context 'when the column type is TIMESTAMP' do
-        let :type do
-          'timestamp without time zone'
-        end
-
-        it 'returns SQL that converts the timestamp to a UNIX timestamp with fractional seconds' do
-          expect(column.to_sql).to eq('(EXTRACT(epoch FROM "the_column") + EXTRACT(milliseconds FROM "the_column")/1000.0)')
         end
       end
 

--- a/spec/bigshift/redshift_unloader_spec.rb
+++ b/spec/bigshift/redshift_unloader_spec.rb
@@ -33,7 +33,7 @@ module BigShift
 
     before do
       allow(redshift_connection).to receive(:exec)
-      allow(redshift_connection).to receive(:exec_params).with(/^SELECT "column", .+ FROM "pg_table_def"/, ['my_schema', 'my_table']).and_return(column_rows)
+      allow(redshift_connection).to receive(:exec_params).with(/^SELECT "column", .+ FROM pg_table_def/, ['my_schema', 'my_table']).and_return(column_rows)
     end
 
     describe '#unload' do


### PR DESCRIPTION
Having made heavy use of your tool on a recent project I have encountered a number of problems which I have resolved on my own fork. I have collected these fixes into a single PR and raised corresponding issues for them.

- Resolve #2 - In commit 8c5e75f I have added the RedShift parameter to limit the size of the unloaded CSV updating the documentation in commit e28e61d 
- Resolve #14 - Reworked the AWS credentials so that either the file or environment can be used in commit 1f7ed0a
- Resolve #15 - Simplified the error handling and simply output location if present instead of attempting to parse it in commit 0c19085 
- Resolve #16 - Removed the bespoke timestamp handling. The default output from RedShift is correctly parsed by BigQuery. Commit bd4916f 
- Resolve #17 - Rewrote the schema query to extract the column positions to preserve them for BigQuery in commit 707df6c 
- Resolve #18 - Manipulated the raw time to schedule in the future to avoid wraparound in commit 5a98691 
- Resolve #19 - Specified the BigQuery option  `allow_quoted_newlines` in commit c48182e 
- Resolve #20 - Reworked GCP credential handling to use the environment (commit 
6f436df) or the compute engine scopes (commit 71fa5a2)
- Resolve #21 - Forced invocations of RedShift to always use a new connection in commit 
d3da6af 